### PR TITLE
Add magic incantation for svg on iOS Fixes #20

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -121,6 +121,11 @@ aside {
     margin-right: auto;
 }
 
+svg {
+    -webkit-transform: translate(0px,0px); /* Safari and Chrome */
+    transform: translate(0px,0px);
+}
+
 #userMessage {
     width: 100%;
     height: 50px;


### PR DESCRIPTION
Fix from good old StackOverflow! https://stackoverflow.com/questions/48873510/off-center-rendering-of-inline-svg-on-ios-safari